### PR TITLE
Fix for warnings in Any.pm

### DIFF
--- a/lib/YAML/Any.pm
+++ b/lib/YAML/Any.pm
@@ -95,7 +95,7 @@ sub LoadFile {
 
 sub order {
     return @YAML::Any::_TEST_ORDER
-        if defined @YAML::Any::_TEST_ORDER;
+        if @YAML::Any::_TEST_ORDER;
     return @implementations;
 }
 


### PR DESCRIPTION
`YAML::Any` generates the following warning with perl 5.16.0:

> defined(@array) is deprecated at /usr/local/perl/perls/perl-5.16.0/lib/site_perl/5.16.0/YAML/Any.pm line 98.

This means that most tests of `Module::CPANTS::Analyse` will fail, because some of the tests use `Test::NoWarnings`.
