### PR TITLE
Fix #13 - test failures under Perl 5.8

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -515,7 +515,7 @@ sub _parse_inline_double_quoted {
     my $self = shift;
     my $node;
     # https://rt.cpan.org/Public/Bug/Display.html?id=90593
-    if ($self->inline =~ /^"((?:(?:\\"|[^"]){0,32766}+){0,32766}+)"\s*(.*)$/) {
+    if ($self->inline =~ /^"((?:(?:\\"|[^"]){0,32766}){0,32766})"\s*(.*)$/) {
         $node = $1;
         $self->inline($2);
         $node =~ s/\\"/"/g;


### PR DESCRIPTION
Trivial change to allow tests to run under Perl 5.8 again. :) Thinking about it, this changes the behaviour slightly (although all tests still pass, including the https://rt.cpan.org/Public/Bug/Display.html?id=90593 test) - I'll have a closer look when I'm not at work...
