### PR TITLE
Force escaping of single '-'

### DIFF
--- a/lib/YAML/Dumper.pm
+++ b/lib/YAML/Dumper.pm
@@ -485,6 +485,7 @@ sub is_valid_plain {
     return 0 if $_[0] =~ /\s#/;
     return 0 if $_[0] =~ /\:(\s|$)/;
     return 0 if $_[0] =~ /[\s\|\>]$/;
+    return 0 if $_[0] eq '-';
     return 1;
 }
 


### PR DESCRIPTION
See SO question - http://stackoverflow.com/questions/23895637/yamldumper-not-quoting-scalar-string#comment36794403_23895637
