### PR TITLE
Disabling warnings

### DIFF
--- a/lib/YAML/Any.pm
+++ b/lib/YAML/Any.pm
@@ -46,6 +46,7 @@ sub import {
 
 sub Dump {
     no strict 'refs';
+    no warnings 'once';
     my $implementation = __PACKAGE__->implementation;
     for my $option (@dump_options) {
         my $var = "$implementation\::$option";
@@ -58,6 +59,7 @@ sub Dump {
 
 sub DumpFile {
     no strict 'refs';
+    no warnings 'once';
     my $implementation = __PACKAGE__->implementation;
     for my $option (@dump_options) {
         my $var = "$implementation\::$option";
@@ -70,6 +72,7 @@ sub DumpFile {
 
 sub Load {
     no strict 'refs';
+    no warnings 'once';
     my $implementation = __PACKAGE__->implementation;
     for my $option (@load_options) {
         my $var = "$implementation\::$option";
@@ -82,6 +85,7 @@ sub Load {
 
 sub LoadFile {
     no strict 'refs';
+    no warnings 'once';
     my $implementation = __PACKAGE__->implementation;
     for my $option (@load_options) {
         my $var = "$implementation\::$option";


### PR DESCRIPTION
Hey! I ran into this at $WORK. I tried producing a decent unit test, but I couldn't manage to squeeze everything into one file.

Basically, with code like...

```
# Foo.pm
use strict;
use warnings;
package Foo;
use YAML::Any;
my $data = YAML::Any::Load("yarr: yarr\n");
1;
```

you get the below warnings:

```
$ perl -MFoo -wle 'print "meh"'
Name "YAML::LoadCode" used only once: possible typo at /home/ad/nigelg/perl5/perlbrew/perls/perl-5.20.0/lib/site_perl/5.20.0/YAML/Any.pm line 77.
Name "YAML::UseCode" used only once: possible typo at /home/ad/nigelg/perl5/perlbrew/perls/perl-5.20.0/lib/site_perl/5.20.0/YAML/Any.pm line 77.
meh
```

This only happens with the -w flag enabled. Not a big thing, but I ran into it on our jenkins server and I had to monkey patch it to pass my builds.

Cheers!
