### PR TITLE
Fix error messaging and prevent silent write failure.

### DIFF
--- a/lib/YAML.pm
+++ b/lib/YAML.pm
@@ -53,7 +53,10 @@ sub DumpFile {
             ($mode, $filename) = ($1, $2);
         }
         open $OUT, $mode, $filename
-          or YAML::Mo::Object->die('YAML_DUMP_ERR_FILE_OUTPUT', $filename, $!);
+          or do {
+              my $errsav = $!;
+              YAML::Mo::Object->die('YAML_DUMP_ERR_FILE_OUTPUT', $filename, $errsav);
+          }
     }
     binmode $OUT, ':utf8';  # if $Config{useperlio} eq 'define';
     local $/ = "\n"; # reset special to "sane"
@@ -68,7 +71,10 @@ sub LoadFile {
     }
     else {
         open $IN, '<', $filename
-          or YAML::Mo::Object->die('YAML_LOAD_ERR_FILE_INPUT', $filename, $!);
+          or do {
+              my $errsav = $!;
+              YAML::Mo::Object->die('YAML_LOAD_ERR_FILE_INPUT', $filename, $errsav);
+          }
     }
     binmode $IN, ':utf8';  # if $Config{useperlio} eq 'define';
     return Load(do { local $/; <$IN> });

--- a/lib/YAML.pm
+++ b/lib/YAML.pm
@@ -61,6 +61,13 @@ sub DumpFile {
     binmode $OUT, ':utf8';  # if $Config{useperlio} eq 'define';
     local $/ = "\n"; # reset special to "sane"
     print $OUT Dump(@_);
+    unless (ref $filename eq 'GLOB') {
+        close $OUT
+          or do {
+              my $errsav = $!;
+              YAML::Mo::Object->die('YAML_DUMP_ERR_FILE_OUTPUT_CLOSE', $filename, $errsav);
+          }
+    }
 }
 
 sub LoadFile {

--- a/lib/YAML/Error.pm
+++ b/lib/YAML/Error.pm
@@ -69,6 +69,8 @@ YAML_DUMP_ERR_FILE_CONCATENATE
   Can't concatenate to YAML file %s
 YAML_DUMP_ERR_FILE_OUTPUT
   Couldn't open %s for output:\n%s
+YAML_DUMP_ERR_FILE_OUTPUT_CLOSE
+  Error closing %s:\n%s
 YAML_DUMP_ERR_NO_HEADER
   With UseHeader=0, the node must be a plain hash or array
 YAML_DUMP_WARN_BAD_NODE_TYPE

--- a/lib/YAML/Error.pm
+++ b/lib/YAML/Error.pm
@@ -32,7 +32,7 @@ sub error_messages {
     $error_messages;
 }
 
-%$error_messages = map {s/^\s+//;$_} split "\n", <<'...';
+%$error_messages = map {s/^\s+//;s/\\n/\n/;$_} split "\n", <<'...';
 YAML_PARSE_ERR_BAD_CHARS
   Invalid characters in stream. This parser only supports printable ASCII
 YAML_PARSE_ERR_NO_FINAL_NEWLINE


### PR DESCRIPTION
Hey Ingy,

There are 3 related patches in my pull request.

The first is to fix a literal '\n' showing up in error messages. This was also reported in issue 113, "verbatim '\n' in error messages [rt.cpan.org #68845]".

Pre-Patch:

$ git checkout 3092ef >/dev/null; perl -e "use lib 'lib'; use YAML; YAML::LoadFile('none')"
Previous HEAD position was 65a2bbb... Prevent silent write failure when DumpFile is passed a filename.
HEAD is now at 3092efd... CPAN Release 1.13
YAML Error: Couldn't open none for input:\n
   Code: YAML_LOAD_ERR_FILE_INPUT
 at lib/YAML.pm line 70.

Post-Patch:

$ git checkout e1a17c >/dev/null; perl -e "use lib 'lib'; use YAML; YAML::LoadFile('none')"
Previous HEAD position was 3092efd... CPAN Release 1.13
HEAD is now at e1a17cb... Fix literal '\n' in error messages.
YAML Error: Couldn't open none for input:

   Code: YAML_LOAD_ERR_FILE_INPUT
 at lib/YAML.pm line 70.

The second is to fix $! getting clobbered (overwritten) before it is passed by value into YAML::Mo::Object->die() (Both above outputs do not have this patch, patched output below). I think this covers issue 118, "Specification for LoadFile (and others) does not state what occurs on error [rt.cpan.org #72571]".

Post-Patch:

$ git checkout 878250 >/dev/null; perl -e "use lib 'lib'; use YAML; YAML::LoadFile('none')"
Previous HEAD position was e1a17cb... Fix literal '\n' in error messages.
HEAD is now at 8782501... Prevent errorno messages from being clobbered before being printed.
YAML Error: Couldn't open none for input:
No such file or directory
   Code: YAML_LOAD_ERR_FILE_INPUT
 at lib/YAML.pm line 76.

The third is to prevent silent write failure when YAML::DumpFile is passed a filename (Both pre-patch and post-patch outputs below).

Pre-Patch:

$ git checkout 878250 >/dev/null; perl -e "use lib 'lib'; use YAML; YAML::DumpFile('/mnt/nospace', '')"
HEAD is now at 8782501... Prevent errorno messages from being clobbered before being printed.

Post-Patch:

$ git checkout 65a2bb >/dev/null; perl -e "use lib 'lib'; use YAML; YAML::DumpFile('/mnt/nospace', '')"
Previous HEAD position was 8782501... Prevent errorno messages from being clobbered before being printed.
HEAD is now at 65a2bbb... Prevent silent write failure when DumpFile is passed a filename.
YAML Error: Error closing /mnt/nospace:
No space left on device
   Code: YAML_DUMP_ERR_FILE_OUTPUT_CLOSE
 at lib/YAML.pm line 68.

Let me know if you need any additional information.

Thanks,
werekraken
