### PR TITLE
Add $YAML::QuoteNumericStrings  setting.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,10 @@
 ---
+version: 1.14
+date:
+changes:
+- Apply PR/145 from @kentnl++
+- Support for QuoteNumericStrings Global Setting
+---
 version: 1.13
 date:    Sat Oct 11 18:05:45 CEST 2014
 changes:

--- a/doc/YAML.swim
+++ b/doc/YAML.swim
@@ -422,6 +422,16 @@ The current options are:
   Since this output is usually more desirable, this option is turned on by
   default.
 
+- QuoteNumericStrings
+
+  Default is 0. (false)
+
+  Adds detection mechanisms to encode strings that resemble numbers with
+  mandatory quoting.
+
+  This ensures leading that things like leading/trailing zeros and other
+  formatting are preserved.
+
 = YAML Terminology
 
 YAML is a full featured data serialization language, and thus has its own

--- a/lib/YAML/Dumper/Base.pm
+++ b/lib/YAML/Dumper/Base.pm
@@ -19,6 +19,7 @@ has inline_series   => default => sub {0};
 has use_aliases     => default => sub {1};
 has purity          => default => sub {0};
 has stringify       => default => sub {0};
+has quote_numeric_strings => default => sub {0};
 
 # Properties
 has stream      => default => sub {''};
@@ -65,6 +66,8 @@ sub set_global_options {
       if defined $YAML::Purity;
     $self->stringify($YAML::Stringify)
       if defined $YAML::Stringify;
+    $self->quote_numeric_strings($YAML::QuoteNumericStrings)
+      if defined $YAML::QuoteNumericStrings;
 }
 
 sub dump {

--- a/test/dump-stringy-numbers.t
+++ b/test/dump-stringy-numbers.t
@@ -1,0 +1,41 @@
+use strict;
+use lib -e 't' ? 't' : 'test';
+use TestYAML tests => 11;
+use YAML ();
+use YAML::Dumper;
+
+$YAML::QuoteNumericStrings = 1;
+filters { perl => [qw'eval yaml_dump'], };
+
+ok( YAML::Dumper->is_literal_number(1),    '1 is a literal number' );
+ok( !YAML::Dumper->is_literal_number("1"), '"1" is not a literal number' );
+ok( YAML::Dumper->is_literal_number( "1" + 1 ), '"1" +1  is a literal number' );
+
+run_is;
+
+__DATA__
+=== Mixed Literal and Stringy ints
++++ perl
++{ foo => '2', baz => 1 }
++++ yaml
+---
+baz: 1
+foo: '2'
+
+=== Mixed Literal and Stringy floats
++++ perl
++{ foo => '2.000', baz => 1.000 }
++++ yaml
+---
+baz: 1
+foo: '2.000'
+
+=== Numeric Keys
++++ perl
++{ 10 => '2.000', 20 => 1.000, '030' => 2.000 }
++++ yaml
+---
+'030': 2
+'10': '2.000'
+'20': 1
+


### PR DESCRIPTION
This allows strings that merely **resemble** numbers ( as opposed to being
provided to perl as a literal number ) being encoded safely as
strings.

This is for feature compatibility with YAML::XS's feature by the same
name.

NOTE: It is presently *disabled* by default as enabling by default has
too many knock-on side-effects and break tests.

For instance, any test with a numeric key stored in a hash
gets those hash keys quoted, because storing it in a hash
converts it from a number to a string.