### PR TITLE
allow quoted map keys in arrays

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -378,7 +378,15 @@ sub _parse_seq {
         else {
             $self->die('YAML_LOAD_ERR_BAD_SEQ_ELEMENT');
         }
-        if ($self->preface =~ /^(\s*)(\w.*\:(?: |$).*)$/) {
+
+        # Check whether the preface looks like a YAML mapping ("key: value").
+        # This is complicated because it has to account for the possibility
+        # that a key is a quoted string, which itself may contain escaped
+        # quotes.
+        my $preface = $self->preface;
+        if ( $preface =~ /^ (\s*) ( \w .*?               \: (?:\ |$).*) $/x  or
+             $preface =~ /^ (\s*) ((['"]) .*? (?<!\\) \3 \s* \: (?:\ |$).*) $/x
+           ) {
             $self->indent($self->offset->[$self->level] + 2 + length($1));
             $self->content($2);
             $self->level($self->level + 1);

--- a/test/bugs-rt.t
+++ b/test/bugs-rt.t
@@ -1,6 +1,6 @@
 use strict;
 use lib -e 't' ? 't' : 'test';
-use TestYAML tests => 41;
+use TestYAML tests => 43;
 
 run_yaml_tests;
 
@@ -62,12 +62,11 @@ MyObj::Class->new();
 
 
 === Ticket #2957 Serializing array-elements with dashes
-+++ skip_this_for_now
+[github #36] The problem is quoted map keys in array elements
 +++ perl: [ { "test - " => 23 } ];
 +++ yaml
 ---
 - 'test - ': 23
-
 
 
 === Ticket #3015 wish: folding length option for YAML
@@ -263,7 +262,7 @@ quoted: "So does this
 
 
 === Ticket #13510 Another roundtrip fails
-+++ skip_this_for_now
+[github #48] The problem is quoted map keys in array elements
 +++ perl
 [{'RR1 (Schloﬂplatz - Wannsee)'=> 1,
 'm‰ﬂiges Kopfsteinpflaster (Teilstrecke)' => 1},
@@ -272,7 +271,7 @@ undef,
 +++ yaml
 ---
 - 'RR1 (Schloﬂplatz - Wannsee)': 1
-  m‰ﬂiges Kopfsteinpflaster (Teilstrecke):  1
+  m‰ﬂiges Kopfsteinpflaster (Teilstrecke): 1
 - ~
 
 


### PR DESCRIPTION
This fixes the situation where a map key has a space in it, causing it
to be quoted, like:

```
- "foo ": bar
- "   baz": fuzz
```

This would result in YAML_PARSE_ERR_SINGLE_LINE.

If the map had multiple items, like:

```
- "june -": 5
  "  july": 6
```

the error would change to YAML_PARSE_ERR_INCONSISTENT_INDENTATION.

Fixes #36

This also fixes #48 

Modified from initial patch by Larry Gilbert (http://l2g.to)

The modified version allows for non-word characters inside the quoted map keys, and combines the two quote characters `'` and `"` into one regex.
