### PR TITLE
Add a newline before the VERSION declaration, to aid EUMM static parsing

### DIFF
--- a/lib/YAML/Mo.pm
+++ b/lib/YAML/Mo.pm
@@ -1,4 +1,5 @@
-package YAML::Mo; $VERSION = '0.88';
+package YAML::Mo;
+$VERSION = '0.88';
 # use Mo qw[builder default import];
 #   The following line of code was produced from the previous line by
 #   Mo::Inline version 0.31


### PR DESCRIPTION
before:
  ~$ perl -MExtUtils::MakeMaker -e 'warn MM->parse_version("lib/YAML/Mo.pm")'
  undef at -e line 1.

after:
  ~$ perl -MExtUtils::MakeMaker -e 'warn MM->parse_version("lib/YAML/Mo.pm")'
  0.88 at -e line 1.