### PR TITLE
Fix issue 77

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -225,7 +225,7 @@ sub _parse_qualifiers {
             $self->die('YAML_PARSE_ERR_MANY_IMPLICIT') if $implicit;
             $implicit = 1;
         }
-        elsif ($preface =~ s/^\&([^ ,:]+)\s*//) {
+        elsif ($preface =~ s/^\&([^ ,:]*)\s*//) {
             $token = $1;
             $self->die('YAML_PARSE_ERR_BAD_ANCHOR')
               unless $token =~ /^[a-zA-Z0-9]+$/;
@@ -233,7 +233,7 @@ sub _parse_qualifiers {
             $self->die('YAML_PARSE_ERR_ANCHOR_ALIAS') if $alias;
             $anchor = $token;
         }
-        elsif ($preface =~ s/^\*([^ ,:]+)\s*//) {
+        elsif ($preface =~ s/^\*([^ ,:]*)\s*//) {
             $token = $1;
             $self->die('YAML_PARSE_ERR_BAD_ALIAS')
               unless $token =~ /^[a-zA-Z0-9]+$/;

--- a/test/errors.t
+++ b/test/errors.t
@@ -1,6 +1,6 @@
 use strict;
 use lib -e 't' ? 't' : 'test';
-use TestYAML tests => 35;
+use TestYAML tests => 37;
 $^W = 1;
 
 use YAML::Error;
@@ -106,6 +106,12 @@ __DATA__
 ---
 - &X=y 42
 
+=== YAML_PARSE_ERR_BAD_ANCHOR
++++ error: YAML_PARSE_ERR_BAD_ANCHOR
++++ yaml
+---
+- &
+
 #---
 #error: YAML_PARSE_ERR_BAD_NODEX
 #load: |
@@ -197,6 +203,12 @@ Test::YAML::Dump({});
 +++ yaml
 ---
 - *foo=bar
+
+=== YAML_PARSE_ERR_BAD_ALIAS
++++ error: YAML_PARSE_ERR_BAD_ALIAS
++++ yaml
+---
+- *
 
 === YAML_PARSE_ERR_MANY_ALIAS
 +++ error: YAML_PARSE_ERR_MANY_ALIAS


### PR DESCRIPTION
A repeated or aliased node without a name would cause an infinite loop
in parsing.  Now it returns an appropriate error.
