### PR TITLE
verbatim '\n' in error messages [rt.cpan.org #68845]

### DIFF
--- a/lib/YAML/Error.pm
+++ b/lib/YAML/Error.pm
@@ -32,7 +32,7 @@ sub error_messages {
     $error_messages;
 }
 
-%$error_messages = map {s/^\s+//;$_} split "\n", <<'...';
+%$error_messages = map {s/^\s+//; s/\\n/\n/g; $_} split "\n", <<'...';
 YAML_PARSE_ERR_BAD_CHARS
   Invalid characters in stream. This parser only supports printable ASCII
 YAML_PARSE_ERR_BAD_MAJOR_VERSION


### PR DESCRIPTION
https://rt.cpan.org/Ticket/Display.html?id=68845

```
Some error messages contain verbatim '\n': '\n' in the error message
definition is not expanded to CR LF or LF.
The problem is in YAML::Error.

Example:

perl -MYAML -e "YAML::LoadFile('none')"
YAML Error: Couldn't open none for input:\nMauvais descripteur de fichier
   Code: YAML_LOAD_ERR_FILE_INPUT
 at -e line 1





-- 
Olivier Mengué - http://search.cpan.org/~dolmen/ http://github.com/dolmen/
```
