### PR TITLE
preserve error message in `$!`

### DIFF
--- a/lib/YAML.pm
+++ b/lib/YAML.pm
@@ -53,7 +53,7 @@ sub DumpFile {
             ($mode, $filename) = ($1, $2);
         }
         open $OUT, $mode, $filename
-          or YAML::Mo::Object->die('YAML_DUMP_ERR_FILE_OUTPUT', $filename, $!);
+          or YAML::Mo::Object->die('YAML_DUMP_ERR_FILE_OUTPUT', $filename, "$!");
     }
     binmode $OUT, ':utf8';  # if $Config{useperlio} eq 'define';
     local $/ = "\n"; # reset special to "sane"
@@ -68,7 +68,7 @@ sub LoadFile {
     }
     else {
         open $IN, '<', $filename
-          or YAML::Mo::Object->die('YAML_LOAD_ERR_FILE_INPUT', $filename, $!);
+          or YAML::Mo::Object->die('YAML_LOAD_ERR_FILE_INPUT', $filename, "$!");
     }
     binmode $IN, ':utf8';  # if $Config{useperlio} eq 'define';
     return Load(do { local $/; <$IN> });


### PR DESCRIPTION
before:
```
% perl -MYAML -e 'YAML::LoadFile("none")'
YAML Error: Couldn't open none for input:\n
   Code: YAML_LOAD_ERR_FILE_INPUT
 at lib/YAML.pm line 70.
```
after:
```
% perl -MYAML -e 'YAML::LoadFile("none")'
YAML Error: Couldn't open none for input:\nNo such file or directory
   Code: YAML_LOAD_ERR_FILE_INPUT
 at lib/YAML.pm line 70.
```
