### PR TITLE
Load B::Deparse at runtime

### DIFF
--- a/lib/YAML/Dumper.pm
+++ b/lib/YAML/Dumper.pm
@@ -7,6 +7,7 @@ use YAML::Dumper::Base;
 use YAML::Node;
 use YAML::Types;
 use Scalar::Util qw();
+use B ();
 
 # Context constants
 use constant KEY       => 3;

--- a/lib/YAML/Types.pm
+++ b/lib/YAML/Types.pm
@@ -137,7 +137,7 @@ sub yaml_dump {
     }
     else {
         bless $value, "CODE" if $class;
-        eval { use B::Deparse };
+        eval { require B::Deparse };
         return if $@;
         my $deparse = B::Deparse->new();
         eval {


### PR DESCRIPTION
So it's loaded only if we need it.
But we need a `use B` in YAML::Dumper for the B:: constants now.

Fixes issues #60 and #75

