### PR TITLE
Fix indent level (trailing null values)

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -638,7 +638,10 @@ sub _parse_next_line {
     $self->die('YAML_EMIT_ERR_BAD_LEVEL') unless defined $offset;
     shift @{$self->lines};
     $self->eos($self->{done} = not @{$self->lines});
-    return if $self->eos;
+    if ($self->eos) {
+        $self->offset->[$level + 1] = $offset + 1;
+        return;
+    }
     $self->{line}++;
 
     # Determine the offset for a new leaf node

--- a/test/load-works.t
+++ b/test/load-works.t
@@ -16,3 +16,9 @@ __DATA__
 +++ yaml
 ---
 foo: bar
+=== empty hashes
++++ perl
++{foo1 => undef, foo2 => undef}
++++ yaml
+foo1:
+foo2:


### PR DESCRIPTION
Before trailing null values were converted to the empty string.
https://rt.cpan.org/Ticket/Display.html?id=82877
Github #131

