### PR TITLE
Fix LoadCode

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -110,7 +110,7 @@ sub _parse_node {
     my $self = shift;
     my $preface = $self->preface;
     $self->preface('');
-    my ($node, $type, $indicator, $chomp) = ('') x 4;
+    my ($node, $type, $indicator, $chomp, $parsed_inline) = ('') x 5;
     my ($anchor, $alias, $explicit, $implicit, $class) = ('') x 5;
     ($anchor, $alias, $explicit, $implicit, $preface) =
       $self->_parse_qualifiers($preface);
@@ -143,6 +143,7 @@ sub _parse_node {
     }
     elsif (length $self->inline) {
         $node = $self->_parse_inline(1, $implicit, $explicit);
+        $parsed_inline = 1;
         if (length $self->inline) {
             $self->die('YAML_PARSE_ERR_SINGLE_LINE');
         }
@@ -193,7 +194,7 @@ sub _parse_node {
             CORE::bless $node, $class;
         }
         else {
-            $node = $self->_parse_explicit($node, $explicit);
+            $node = $self->_parse_explicit($node, $explicit) if !$parsed_inline;
         }
     }
     if ($anchor) {

--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -110,7 +110,7 @@ sub _parse_node {
     my $self = shift;
     my $preface = $self->preface;
     $self->preface('');
-    my ($node, $type, $indicator, $escape, $chomp) = ('') x 5;
+    my ($node, $type, $indicator, $chomp) = ('') x 4;
     my ($anchor, $alias, $explicit, $implicit, $class) = ('') x 5;
     ($anchor, $alias, $explicit, $implicit, $preface) =
       $self->_parse_qualifiers($preface);

--- a/test/load-code.t
+++ b/test/load-code.t
@@ -1,0 +1,27 @@
+use strict;
+use lib -e 't' ? 't' : 'test';
+use TestYAML tests => 4;
+
+run_roundtrip_nyn('dumper');
+
+__DATA__
+
+=== Actually test LoadCode functionality, block
++++ perl: $YAML::UseCode = 1; package main; sub { 42 }
++++ yaml
+--- !!perl/code |
+{
+    use warnings;
+    use strict;
+    42;
+}
+
+=== Actually test LoadCode functionality, block
++++ perl: $YAML::UseCode = 1; package main; no warnings; sub { 42 }
++++ yaml
+--- !!perl/code |
+{
+    no warnings;
+    use strict;
+    42;
+}

--- a/test/load-code.t
+++ b/test/load-code.t
@@ -1,6 +1,6 @@
 use strict;
 use lib -e 't' ? 't' : 'test';
-use TestYAML tests => 4;
+use TestYAML tests => 6;
 
 run_roundtrip_nyn('dumper');
 
@@ -25,3 +25,8 @@ __DATA__
     use strict;
     42;
 }
+
+=== Actually test LoadCode functionality, line
++++ perl: $YAML::UseCode = 1; package main; no strict; sub { 42 }
++++ yaml
+--- !!perl/code "{\n    use warnings;\n    42;\n}\n"


### PR DESCRIPTION
With an `inline` value, it was both getting `_parse_inline` AND (if `$explicit`) also `_parse_explicit`. A guard variable now prevents that. All tests old and new still pass.

(I also removed an unused variable in `_parse_node`: `$escape`)