### PR TITLE
Support trailing comments where this has been an error before

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -120,7 +120,7 @@ sub _parse_node {
     $self->inline('');
     while (length $preface) {
         my $line = $self->line - 1;
-        if ($preface =~ s/^($FOLD_CHAR|$LIT_CHAR_RX)(-|\+)?\d*\s*//) {
+        if ($preface =~ s/^($FOLD_CHAR|$LIT_CHAR_RX)(-|\+)?\d*(?:\s+#.*$|\s*)//) {
             $indicator = $1;
             $chomp = $2 if defined($2);
         }
@@ -476,7 +476,7 @@ sub _parse_inline_mapping {
 
     $self->die('YAML_PARSE_ERR_INLINE_MAP')
       unless $self->{inline} =~ s/^\{\s*//;
-    while (not $self->{inline} =~ s/^\s*\}\s*//) {
+    while (not $self->{inline} =~ s/^\s*\}(\s+#.*$|\s*)//) {
         my $key = $self->_parse_inline();
         $self->die('YAML_PARSE_ERR_INLINE_MAP')
           unless $self->{inline} =~ s/^\: \s*//;
@@ -503,7 +503,7 @@ sub _parse_inline_seq {
 
     $self->die('YAML_PARSE_ERR_INLINE_SEQUENCE')
       unless $self->{inline} =~ s/^\[\s*//;
-    while (not $self->{inline} =~ s/^\s*\]\s*//) {
+    while (not $self->{inline} =~ s/^\s*\](\s+#.*$|\s*)//) {
         my $value = $self->_parse_inline();
         push @$node, $value;
         next if $self->inline =~ /^\s*\]/;
@@ -526,7 +526,7 @@ sub _parse_inline_double_quoted {
             $node .= $capture;
             last unless length $inline;
         }
-        if ($inline =~ s/^"\s*//) {
+        if ($inline =~ s/^"(?:\s+#.*|\s*)//) {
             $self->inline($inline);
             return $node;
         }
@@ -547,7 +547,7 @@ sub _parse_inline_single_quoted {
             $node .= $capture;
             last unless length $inline;
         }
-        if ($inline =~ s/^'\s*//) {
+        if ($inline =~ s/^'(?:\s+#.*|\s*)//) {
             $self->inline($inline);
             return $node;
         }
@@ -651,8 +651,9 @@ sub _parse_next_line {
     $self->{line}++;
 
     # Determine the offset for a new leaf node
+    # TODO
     if ($self->preface =~
-        qr/(?:^|\s)(?:$FOLD_CHAR|$LIT_CHAR_RX)(?:-|\+)?(\d*)\s*$/
+        qr/(?:^|\s)(?:$FOLD_CHAR|$LIT_CHAR_RX)(?:-|\+)?(\d*)(?:\s+#.*|\s*)$/
        ) {
         $self->die('YAML_PARSE_ERR_ZERO_INDENT')
           if length($1) and $1 == 0;

--- a/test/trailing-comments-non-content.t
+++ b/test/trailing-comments-non-content.t
@@ -1,0 +1,81 @@
+use strict;
+use lib -e 't' ? 't' : 'test';
+use TestYAML tests => 7;
+
+# testing trailing comments which were errors before
+
+run {
+    my $block = shift;
+    my @result = eval {
+        Load($block->yaml)
+    };
+    my $error1 = $@ || '';
+    if ( $error1 ) {
+        # $error1 =~ s{line: (\d+)}{"line: $1   ($0:".($1+$test->{lines}{yaml}-1).")"}e;
+    }
+    my @expect = eval $block->perl;
+    my $error2 = $@ || '';
+    if (my $errors = $error1 . $error2) {
+        fail($block->description
+              . $errors);
+        next;
+    }
+    is_deeply(
+        \@result,
+        \@expect,
+        $block->description,
+    ) or do {
+        require Data::Dumper;
+        diag("Wanted: ".Data::Dumper::Dumper(\@expect));
+        diag("Got: ".Data::Dumper::Dumper(\@result));
+    }
+};
+
+__DATA__
+
+=== Comment after inline seq
++++ yaml
+---
+seq: [314] #comment
++++ perl
+{ seq => [314] }
+
+=== Comment after inline map
++++ yaml
+---
+map: {x: y} #comment
++++ perl
+{ map => { x => 'y' }, }
+
+=== Comment after literal block scalar indicator
++++ yaml
+---
+- |- #comment
++++ perl
+['']
+
+=== Comment after folded block scalar indicator
++++ yaml
+---
+- >- #comment
++++ perl
+['']
+
+=== Comment after top level literal block scalar indicator
++++ yaml
+--- |- #comment
++++ perl
+''
+=== Comment after double quoted string
++++ yaml
+---
+quoted: "string" #comment
++++ perl
+{ quoted => 'string' }
+
+=== Comment after single quoted string
++++ yaml
+---
+quoted: 'string'  #comment
++++ perl
+{ quoted => 'string' }


### PR DESCRIPTION
In these cases we can just support it without making it optional

This should wait for #188 being merged, as comments after quoted strings still have to be added