### PR TITLE
Fix loading of mapping key which starts with `= `

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -322,11 +322,11 @@ sub _parse_mapping {
             $key = "$key";
         }
         # If "default" key (equals sign)
-        elsif ($self->{content} =~ s/^\=\s*//) {
+        elsif ($self->{content} =~ s/^\=\s*(?=:)//) {
             $key = VALUE;
         }
         # If "comment" key (slash slash)
-        elsif ($self->{content} =~ s/^\=\s*//) {
+        elsif ($self->{content} =~ s/^\=\s*(?=:)//) {
             $key = COMMENT;
         }
         # Regular scalar key:


### PR DESCRIPTION
See issue #130

