### PR TITLE
Allow more characters in anchor

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -228,7 +228,7 @@ sub _parse_qualifiers {
         elsif ($preface =~ s/^\&([^ ,:]*)\s*//) {
             $token = $1;
             $self->die('YAML_PARSE_ERR_BAD_ANCHOR')
-              unless $token =~ /^[a-zA-Z0-9]+$/;
+              unless $token =~ /^[a-zA-Z0-9_.\/-]+$/;
             $self->die('YAML_PARSE_ERR_MANY_ANCHOR') if $anchor;
             $self->die('YAML_PARSE_ERR_ANCHOR_ALIAS') if $alias;
             $anchor = $token;

--- a/test/load-tests.t
+++ b/test/load-tests.t
@@ -1,6 +1,6 @@
 use strict;
 use lib -e 't' ? 't' : 'test';
-use TestYAML tests => 32;
+use TestYAML tests => 33;
 use Test::Deep;
 
 run {
@@ -421,3 +421,12 @@ bless(do { my $x = 1; \$x}, "moose")
 --- "   ABC"
 +++ perl
 '   ABC'
+=== Allowed characters in anchors
++++ yaml
+---
+- &a.1 a
+- &b/2 b
+- &c_3 c
+- &d-4 d
++++ perl
+['a', 'b', 'c', 'd']


### PR DESCRIPTION
Add `-_/.`

Allowing all characters that are allowed by the spec is currently not
planned.

See #127 