### PR TITLE
Disable test with long string under certain conditions

### DIFF
--- a/test/2-scalars.t
+++ b/test/2-scalars.t
@@ -2,6 +2,7 @@
 use strict;
 use Test::More;
 
+use Config;
 require YAML;
 YAML->import;
 
@@ -29,9 +30,12 @@ my $Data = {
 is_deeply(Load(Dump($Data)), $Data);
 
 if ($^V ge v5.9.0) {
-# Large data tests. See also https://bugzilla.redhat.com/show_bug.cgi?id=192400.
-    $Data = ' äø<> " \' " \'' x 40_000;
-    is(Load(Dump($Data)), $Data);
+    # see https://github.com/ingydotnet/yaml-pm/issues/186
+    unless ($Config{config_args} =~ / \-fsanitize \= (?: address | undefined ) \b /x) {
+        # Large data tests. See also https://bugzilla.redhat.com/show_bug.cgi?id=192400.
+        $Data = ' äø<> " \' " \'' x 40_000;
+        is(Load(Dump($Data)), $Data);
+    }
 }
 
 {


### PR DESCRIPTION
Because they are running too long.

See #186

