### PR TITLE
Add support for compact nested block sequences

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -385,7 +385,17 @@ sub _parse_seq {
         # that a key is a quoted string, which itself may contain escaped
         # quotes.
         my $preface = $self->preface;
-        if ( $preface =~ /^ (\s*) ( \w .*?               \: (?:\ |$).*) $/x  or
+        if ($preface =~ m/^ (\s*) ( - (?: \ .* | $ ) ) /x) {
+            $self->indent($self->offset->[$self->level] + 2 + length($1));
+            $self->content($2);
+            $self->level($self->level + 1);
+            $self->offset->[$self->level] = $self->indent;
+            $self->preface('');
+            push @$seq, $self->_parse_seq('');
+            $self->{level}--;
+            $#{$self->offset} = $self->level;
+        }
+        elsif ( $preface =~ /^ (\s*) ( \w .*?               \: (?:\ |$).*) $/x  or
              $preface =~ /^ (\s*) ((') (?:''|[^'])*? ' \s* \: (?:\ |$).*) $/x or
              $preface =~ /^ (\s*) ((") (?:\\\\|[^"])*? " \s* \: (?:\ |$).*) $/x
            ) {

--- a/test/load-tests.t
+++ b/test/load-tests.t
@@ -1,6 +1,6 @@
 use strict;
 use lib -e 't' ? 't' : 'test';
-use TestYAML tests => 33;
+use TestYAML tests => 34;
 use Test::Deep;
 
 run {
@@ -430,3 +430,17 @@ bless(do { my $x = 1; \$x}, "moose")
 - &d-4 d
 +++ perl
 ['a', 'b', 'c', 'd']
+
+=== Compact nested block sequences
++++ yaml
+- - a
+  -  b
+  - - 1
+  -  - 2
+     - 3
+- - [c]
++++ perl
+[
+    ['a', 'b', [1], [2,3] ],
+    [ ['c'] ],
+]


### PR DESCRIPTION
Example from test that resulted in an error previously:

```
- - a
  -  b
  - - 1
  -  - 2
     - 3
- - [c]
```

