### PR TITLE
Support nested mappings in sequences

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -404,9 +404,11 @@ sub _parse_seq {
             $self->{level}--;
             $#{$self->offset} = $self->level;
         }
-        elsif ( $preface =~ /^ (\s*) ( \w .*?               \: (?:\ |$).*) $/x  or
+        elsif (
              $preface =~ /^ (\s*) ((') (?:''|[^'])*? ' \s* \: (?:\ |$).*) $/x or
-             $preface =~ /^ (\s*) ((") (?:\\\\|[^"])*? " \s* \: (?:\ |$).*) $/x
+             $preface =~ /^ (\s*) ((") (?:\\\\|[^"])*? " \s* \: (?:\ |$).*) $/x or
+             $preface =~ /^ (\s*) (\?.*$)/x or
+             $preface =~ /^ (\s*) ([^\s:#&!\[\]\{\},*|>].*\:(\ .*|$))/x
            ) {
             $self->indent($self->offset->[$self->level] + 2 + length($1));
             $self->content($2);

--- a/test/load-tests.t
+++ b/test/load-tests.t
@@ -1,6 +1,6 @@
 use strict;
 use lib -e 't' ? 't' : 'test';
-use TestYAML tests => 35;
+use TestYAML tests => 37;
 use Test::Deep;
 
 run {
@@ -468,3 +468,19 @@ d: >2+
     d => "  1\n2\n",
 }
 
+=== Nested explicit key
++++ yaml
+---
+- ? a
+  : b
++++ perl
+[{ a => 'b' }]
+
+=== Nested mappings with non \w keys
++++ yaml
+---
+- .: a
+  <: b
+  -: c
++++ perl
+[ { '.' => 'a', '<' => 'b', '-' => 'c' } ]


### PR DESCRIPTION
Currently, the following will be an error:

```
echo '---
- ? a
  : b' | ysh -MYAML
YAML Error: Inconsistent indentation level
   Code: YAML_PARSE_ERR_INCONSISTENT_INDENTATION
```

And this will be loaded incorrectly:
```
echo '---
- .: a' | ysh -MYAML
$VAR1 = [
  '.: a'
];

```

This patch fixes both.

