### PR TITLE
Support zero indented block sequences

### DIFF
--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -43,6 +43,7 @@ sub _parse {
     $self->_parse_throwaway_comments();
     $self->document(0);
     $self->documents([]);
+    $self->zero_indent([]);
     # Add an "assumed" header if there is no header and the stream is
     # not empty (after initial throwaways).
     if (not $self->eos) {
@@ -363,8 +364,15 @@ sub _parse_mapping {
         }
         $self->preface($self->content);
         my $line = $self->line;
+        my $level = $self->level;
+
+        # we can get a zero indented sequence, possibly
+        my $zero_indent = $self->zero_indent;
+        $zero_indent->[ $level ] = 0;
         $self->_parse_next_line(COLLECTION);
         my $value = $self->_parse_node();
+        $#$zero_indent = $level;
+
         if (exists $mapping->{$key}) {
             $self->warn('YAML_LOAD_WARN_DUPLICATE_KEY', $key);
         }
@@ -386,6 +394,9 @@ sub _parse_seq {
             $self->preface(defined($1) ? $1 : '');
         }
         else {
+            if ($self->zero_indent->[ $self->level ]) {
+                last;
+            }
             $self->die('YAML_LOAD_ERR_BAD_SEQ_ELEMENT');
         }
 
@@ -720,9 +731,21 @@ sub _parse_next_line {
     elsif ($type == COLLECTION and
            $self->preface =~ /^(\s*(\!\S*|\&\S+))*\s*$/) {
         $self->_parse_throwaway_comments();
+        my $zero_indent = $self->zero_indent;
         if ($self->eos) {
             $self->offset->[$level+1] = $offset + 1;
             return;
+        }
+        elsif (
+            defined $zero_indent->[ $level ]
+            and not $zero_indent->[ $level ]
+            and $self->lines->[0] =~ /^( {$offset,})-(?: |$)/
+        ) {
+            my $new_offset = length($1);
+            $self->offset->[$level+1] = $new_offset;
+            if ($new_offset == $offset) {
+                $zero_indent->[ $level+1 ] = 1;
+            }
         }
         else {
             $self->lines->[0] =~ /^( *)\S/ or

--- a/lib/YAML/Loader.pm
+++ b/lib/YAML/Loader.pm
@@ -128,7 +128,6 @@ sub _parse_node {
     }
     $self->inline('');
     while (length $preface) {
-        my $line = $self->line - 1;
         if ($preface =~ s/^($FOLD_CHAR|$LIT_CHAR_RX)//) {
             $indicator = $1;
             if ($preface =~ s/^([+-])[0-9]*//) {
@@ -226,7 +225,6 @@ sub _parse_qualifiers {
     my ($anchor, $alias, $explicit, $implicit, $token) = ('') x 5;
     $self->inline('');
     while ($preface =~ /^[&*!]/) {
-        my $line = $self->line - 1;
         if ($preface =~ s/^\!(\S+)\s*//) {
             $self->die('YAML_PARSE_ERR_MANY_EXPLICIT') if $explicit;
             $explicit = $1;
@@ -363,7 +361,6 @@ sub _parse_mapping {
             $self->die('YAML_LOAD_ERR_BAD_MAP_ELEMENT');
         }
         $self->preface($self->content);
-        my $line = $self->line;
         my $level = $self->level;
 
         # we can get a zero indented sequence, possibly

--- a/lib/YAML/Loader/Base.pm
+++ b/lib/YAML/Loader/Base.pm
@@ -21,6 +21,7 @@ has major_version => default => sub {0};
 has minor_version => default => sub {0};
 has inline        => default => sub {''};
 has numify        => default => sub {0};
+has zero_indent   => default => sub {[]};
 
 sub set_global_options {
     my $self = shift;

--- a/test/errors.t
+++ b/test/errors.t
@@ -1,6 +1,6 @@
 use strict;
 use lib -e 't' ? 't' : 'test';
-use TestYAML tests => 38;
+use TestYAML tests => 39;
 $^W = 1;
 
 use YAML::Error;
@@ -405,4 +405,12 @@ foo: bar
 ---
 some:
   	data-preceded-with-tab: abc
+=== YAML_PARSE_ERR_INCONSISTENT_INDENTATION
++++ error: YAML_PARSE_ERR_INCONSISTENT_INDENTATION
++++ yaml
+---
+a:
+  b:
+ - 1
+ - 2
 

--- a/test/load-tests.t
+++ b/test/load-tests.t
@@ -1,6 +1,6 @@
 use strict;
 use lib -e 't' ? 't' : 'test';
-use TestYAML tests => 37;
+use TestYAML tests => 38;
 use Test::Deep;
 
 run {
@@ -484,3 +484,34 @@ d: >2+
   -: c
 +++ perl
 [ { '.' => 'a', '<' => 'b', '-' => 'c' } ]
+
+=== Zero indented block sequence
++++ yaml
+a:
+  b:
+  -
+  -
+c:
+ -
+ -
+d:
+- 1
+- 2
+e:
+  - 3
+  - 4
+  - f:
+    - 5
+    - 6
+    g: 7
++++ perl
+{
+    a => { b => [ undef, undef ] },
+    c => [undef, undef],
+    d => [1, 2],
+    e => [3, 4, {
+        f => [5, 6],
+        g => 7,
+    }],
+}
+


### PR DESCRIPTION
This patch will allow block sequences on the same level as the parent mapping,
like:

```
x:
- a
- b
y: z
```

Both YAML 1.1 and 1.2 allow zero indented sequences.

There are people who insist that the Spec is inconsistent, and modules
which produce zero indented sequences are broken.

So here are some quotes from the 1.2 spec which is similar to 1.1:

```
Since people perceive the “-” indicator as indentation, nested block sequences
may be indented by one less space to compensate, except, of course, if nested
inside another block sequence (block-out context vs. block-in context).
```

* http://yaml.org/spec/1.2/spec.html#id2799181 8.2.3 Block Nodes
```
[201] seq-spaces(n,c) ::= c = block-out ⇒ n-1
                          c = block-in  ⇒ n
```

```
Example 8.22. Block Collection Nodes

sequence: !!seq
- entry
- !!seq
 - nested
mapping: !!map
 foo: bar
```
Fixes:
* #92 

Related:
* https://github.com/ingydotnet/yaml-libyaml-pm/issues/9
* https://github.com/ingydotnet/yaml-libyaml-pm/issues/44